### PR TITLE
Remove each - thats deprecated on php 7.2

### DIFF
--- a/src/LynX39/LaraPdfMerger/tcpdf/tcpdi.php
+++ b/src/LynX39/LaraPdfMerger/tcpdf/tcpdi.php
@@ -484,7 +484,7 @@ class TCPDI extends FPDF_TPL {
 
                 reset ($value[1]);
 
-                while (list($k, $v) = each($value[1])) {
+                foreach($value[1] as $k=>$v) {
                     $this->_straightOut($k . ' ');
                     $this->pdf_write_value($v);
                 }


### PR DESCRIPTION
Hi. The each method is deprecated on php 7.2. I've fixed like suggested here: https://github.com/tecnickcom/TCPDF/pull/74/files